### PR TITLE
Use CodePipeline to deploy web app

### DIFF
--- a/terraform/infrastructure/main.tf
+++ b/terraform/infrastructure/main.tf
@@ -13,6 +13,11 @@ provider "aws" {
   version = "~> 1.41"
 }
 
+provider "github" {
+  organization = "knowmetools"
+  version      = "~> 1.3"
+}
+
 provider "null" {
   version = "~> 2.0"
 }
@@ -96,11 +101,11 @@ module "webapp" {
 module "webapp_build" {
   source = "./webapp-codebuild"
 
-  api_root  = "https://${local.api_domain}"
-  app_slug  = "${local.full_name_slug}"
-  base_tags = "${local.base_tags}"
-  s3_arn    = "${module.webapp.s3_bucket_arn}"
-  s3_bucket = "${module.webapp.s3_bucket}"
+  api_root          = "https://${local.api_domain}"
+  app_slug          = "${local.full_name_slug}"
+  base_tags         = "${local.base_tags}"
+  deploy_bucket     = "${module.webapp.s3_bucket}"
+  source_repository = "km-web"
 }
 
 ################################################################################

--- a/terraform/infrastructure/webapp-codebuild/main.tf
+++ b/terraform/infrastructure/webapp-codebuild/main.tf
@@ -1,4 +1,109 @@
-data "aws_region" "current" {}
+data "aws_s3_bucket" "deploy" {
+  bucket = "${var.deploy_bucket}"
+}
+
+data "github_repository" "webapp" {
+  name = "${var.source_repository}"
+}
+
+################################################################################
+#                             Web App CodePipeline                             #
+################################################################################
+
+resource "aws_codepipeline" "webapp" {
+  name     = "${var.app_slug}-web-app-pipeline"
+  role_arn = "${aws_iam_role.codepipeline.arn}"
+
+  artifact_store {
+    location = "${aws_s3_bucket.artifacts.bucket}"
+    type     = "S3"
+  }
+
+  stage {
+    name = "Source"
+
+    action {
+      category         = "Source"
+      name             = "Source"
+      output_artifacts = ["source"]
+      owner            = "ThirdParty"
+      provider         = "GitHub"
+      version          = "1"
+
+      configuration = {
+        Branch = "${var.source_branch}"
+        Owner  = "knowmetools"
+        Repo   = "${data.github_repository.webapp.name}"
+      }
+    }
+  }
+
+  stage {
+    name = "Build"
+
+    action {
+      category         = "Build"
+      input_artifacts  = ["source"]
+      name             = "Build"
+      output_artifacts = ["build"]
+      owner            = "AWS"
+      provider         = "CodeBuild"
+      version          = "1"
+
+      configuration = {
+        ProjectName = "${aws_codebuild_project.webapp.name}"
+      }
+    }
+  }
+
+  stage {
+    name = "Deploy"
+
+    action {
+      category        = "Deploy"
+      input_artifacts = ["build"]
+      name            = "Deploy"
+      owner           = "AWS"
+      provider        = "S3"
+      version         = "1"
+
+      configuration {
+        BucketName = "${var.deploy_bucket}"
+        Extract    = "true"
+      }
+    }
+  }
+}
+
+resource "aws_codepipeline_webhook" "bar" {
+  name            = "${var.app_slug}-web-app-hook"
+  authentication  = "GITHUB_HMAC"
+  target_action   = "Source"
+  target_pipeline = "${aws_codepipeline.webapp.name}"
+
+  authentication_configuration {
+    secret_token = "${random_string.webhook_secret.result}"
+  }
+
+  filter {
+    json_path    = "$.ref"
+    match_equals = "refs/heads/${var.source_branch}"
+  }
+}
+
+resource "github_repository_webhook" "bar" {
+  repository = "${data.github_repository.webapp.name}"
+  name       = "web"
+
+  configuration {
+    url          = "${aws_codepipeline_webhook.bar.url}"
+    content_type = "json"
+    insecure_ssl = true
+    secret       = "${random_string.webhook_secret.result}"
+  }
+
+  events = ["push"]
+}
 
 ################################################################################
 #                               CodeBuild Project                              #
@@ -8,11 +113,11 @@ resource "aws_codebuild_project" "webapp" {
   build_timeout = 5
   description   = "Automatically deploy changes to the ${var.app_slug} web application."
   name          = "${var.app_slug}-webapp"
-  service_role  = "${aws_iam_role.codebuild.name}"
+  service_role  = "${aws_iam_role.codebuild.arn}"
   tags          = "${var.base_tags}"
 
   artifacts {
-    type = "NO_ARTIFACTS"
+    type = "CODEPIPELINE"
   }
 
   environment {
@@ -24,37 +129,92 @@ resource "aws_codebuild_project" "webapp" {
       name  = "REACT_APP_API_ROOT"
       value = "${var.api_root}"
     }
-
-    environment_variable {
-      name  = "S3_BUCKET"
-      value = "${var.s3_bucket}"
-    }
   }
 
   source {
-    git_clone_depth = 1
-    location        = "https://github.com/knowmetools/km-web.git"
-    type            = "GITHUB"
+    type = "CODEPIPELINE"
   }
 }
 
-# Webhook to run CodeBuild when the source code changes
-resource "aws_codebuild_webhook" "webapp" {
-  branch_filter = "${var.source_branch}"
-  project_name  = "${aws_codebuild_project.webapp.name}"
+################################################################################
+#                              Artifact S3 Bucket                              #
+################################################################################
+
+resource "aws_s3_bucket" "artifacts" {
+  bucket_prefix = "${var.app_slug}-web-artifacts"
+  force_destroy = true
+
+  tags = "${merge(
+    var.base_tags,
+    map("Name", "${var.app_slug} Web App Artifacts")
+  )}"
 }
 
-# If we just created the CodeBuild project, trigger an initial run so
-# that we don't have to push a change to the webapp for it to be
-# deployed for the first time.
-resource "null_resource" "initial_codebuild" {
-  provisioner "local-exec" {
-    command = "aws codebuild start-build --project-name ${aws_codebuild_project.webapp.name} --region ${data.aws_region.current.name} --source-version ${var.source_branch}"
-  }
+################################################################################
+#                           IAM Role for CodePipeline                          #
+################################################################################
 
-  triggers {
-    project_name = "${aws_codebuild_project.webapp.name}"
-  }
+resource "aws_iam_role" "codepipeline" {
+  name = "${var.app_slug}-web-app-code-pipeline"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "codepipeline.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "codepipeline_policy" {
+  name = "${var.app_slug}-web-app-code-pipeline-artifacts"
+  role = "${aws_iam_role.codepipeline.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect":"Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+        "s3:GetBucketVersioning",
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "${aws_s3_bucket.artifacts.arn}",
+        "${aws_s3_bucket.artifacts.arn}/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "codebuild:BatchGetBuilds",
+        "codebuild:StartBuild"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect":"Allow",
+      "Action": [
+        "s3:*"
+      ],
+      "Resource": [
+        "${data.aws_s3_bucket.deploy.arn}",
+        "${data.aws_s3_bucket.deploy.arn}/*"
+      ]
+    }
+  ]
+}
+EOF
 }
 
 ################################################################################
@@ -80,7 +240,32 @@ resource "aws_iam_role" "codebuild" {
 EOF
 }
 
-resource "aws_iam_role_policy" "codebuild-log" {
+resource "aws_iam_role_policy" "codebuild_artifacts" {
+  role = "${aws_iam_role.codebuild.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect":"Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+        "s3:GetBucketVersioning",
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "${aws_s3_bucket.artifacts.arn}",
+        "${aws_s3_bucket.artifacts.arn}/*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "codebuild_log" {
   role = "${aws_iam_role.codebuild.name}"
 
   policy = <<POLICY
@@ -103,24 +288,10 @@ resource "aws_iam_role_policy" "codebuild-log" {
 POLICY
 }
 
-resource "aws_iam_role_policy" "codebuild-deploy" {
-  role = "${aws_iam_role.codebuild.name}"
+################################################################################
+#                                    Secrets                                   #
+################################################################################
 
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:*"
-      ],
-      "Resource": [
-        "${var.s3_arn}",
-        "${var.s3_arn}/*"
-      ]
-    }
-  ]
-}
-POLICY
+resource "random_string" "webhook_secret" {
+  length = 32
 }

--- a/terraform/infrastructure/webapp-codebuild/vars.tf
+++ b/terraform/infrastructure/webapp-codebuild/vars.tf
@@ -12,15 +12,15 @@ variable "base_tags" {
   type        = "map"
 }
 
-variable "s3_arn" {
-  description = "The ARN of the S3 bucket that the webapp is uploaded to."
-}
-
-variable "s3_bucket" {
-  description = "The name of the S3 bucket that the webapp is uploaded to."
+variable "deploy_bucket" {
+  description = "The name of the S3 bucket to deploy the web app to."
 }
 
 variable "source_branch" {
   default     = "master"
   description = "The name of the branch to listen to changes on."
+}
+
+variable "source_repository" {
+  description = "The name (without organization) of the GitHub repository containing the source for the web app."
 }


### PR DESCRIPTION
We were having issues with filtering the branches that were automatically deployed using CodeBuild. By switching to CodePipeline we were able to resolve those issues and simplify our deployment process at the same time.

Fixes #10