### PR TITLE
Restore outputs for database credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ edit it directly.
             * [Delete Old Bucket](#delete-old-bucket)
       * [License](#license)
 
-<!-- Added by: chathan, at: Fri May 31 14:54:16 EDT 2019 -->
+<!-- Added by: chathan, at: Sun Jun  2 10:48:55 EDT 2019 -->
 
 <!--te-->
 
@@ -493,11 +493,12 @@ To backup the old database, run the following:
 pg_dump -d appdb -h $HOSTNAME -U $USER > dump.sql
 ```
 
-Credentials can be obtained from Terraform:
+Credentials can be obtained from Terraform. Pick the appropriate prefix based on
+the environment you are targeting (`staging` or `production`):
 
 ```
-terraform output database_user
-terraform output database_password
+terraform output staging_db_user
+terraform output staging_db_password
 ```
 
 #### Create New Database
@@ -514,11 +515,12 @@ terraform apply tfplan
 #### Create Role
 
 Before we can restore the database, we have to create the app database user.
-First, obtain the admin credentials using:
+First, obtain the admin credentials using the following command, selecting the
+appropriate environment (`production` or `staging`):
 
 ```
-terraform output database_admin_user
-terraform output database_admin_password
+terraform output staging_db_admin_user
+terraform output staging_db_admin_password
 ```
 
 Then log in as the admin user.
@@ -533,11 +535,13 @@ Execute the following statement:
 CREATE ROLE app_db_user WITH LOGIN PASSWORD '$PASSWORD';
 ```
 
-The credentials to use here can again be pulled from Terraform:
-
+The credentials to use here can again be pulled from Terraform. Pick the
+appropriate prefix based on the environment you are targeting (`staging` or 
+`production`):
+                                                                
 ```
-terraform output database_user
-terraform output database_password
+terraform output staging_db_user
+terraform output staging_db_password
 ```
 
 #### Restore Data

--- a/terraform/application/api/outputs.tf
+++ b/terraform/application/api/outputs.tf
@@ -2,12 +2,26 @@ output "database_admin_password_ssm_param" {
   value = aws_ssm_parameter.db_admin_password
 }
 
+output "database_admin_password" {
+  sensitive = true
+  value     = module.db.instance.password
+}
+
 output "database_admin_user" {
   value = module.db.instance.username
 }
 
+output "database_password" {
+  sensitive = true
+  value     = random_string.db_password.result
+}
+
 output "database_password_ssm_param" {
   value = aws_ssm_parameter.db_password
+}
+
+output "database_user" {
+  value = var.application_db_user
 }
 
 output "ecs_cluster" {

--- a/terraform/application/outputs.tf
+++ b/terraform/application/outputs.tf
@@ -46,6 +46,11 @@ output "api_web_container_port" {
   value = module.api.web_container_port
 }
 
+output "database_admin_password" {
+  sensitive = true
+  value     = module.api.database_admin_password
+}
+
 output "database_admin_password_ssm_param" {
   value = module.api.database_admin_password_ssm_param
 }
@@ -54,8 +59,17 @@ output "database_admin_user" {
   value = module.api.database_admin_user
 }
 
+output "database_password" {
+  sensitive = true
+  value     = module.api.database_password
+}
+
 output "database_password_ssm_param" {
   value = module.api.database_password_ssm_param
+}
+
+output "database_user" {
+  value = module.api.database_user
 }
 
 output "web_app_s3_bucket" {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -7,6 +7,24 @@ output "production_admin_password" {
   value     = module.deployment.production_admin_password
 }
 
+output "production_db_admin_password" {
+  sensitive = true
+  value     = module.prod_app.database_admin_password
+}
+
+output "production_db_admin_user" {
+  value = module.prod_app.database_admin_user
+}
+
+output "production_db_password" {
+  sensitive = true
+  value     = module.prod_app.database_password
+}
+
+output "production_db_user" {
+  value = module.prod_app.database_user
+}
+
 output "staging_admin_email" {
   value = var.admin_email
 }
@@ -14,4 +32,22 @@ output "staging_admin_email" {
 output "staging_admin_password" {
   sensitive = true
   value     = module.deployment.staging_admin_password
+}
+
+output "staging_db_admin_password" {
+  sensitive = true
+  value     = module.staging_app.database_admin_password
+}
+
+output "staging_db_admin_user" {
+  value = module.staging_app.database_admin_user
+}
+
+output "staging_db_password" {
+  sensitive = true
+  value     = module.staging_app.database_password
+}
+
+output "staging_db_user" {
+  value = module.staging_app.database_user
 }


### PR DESCRIPTION
These credentials are primarily used if we ever need to do manual
database backups or restores.

Closes #29